### PR TITLE
Drop xaringanBuilder, add fontawesome

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -17,3 +17,5 @@ install.packages("xaringanthemer", dependencies = TRUE)
 # Extra Packages ----------------------------------------------------------
 install.packages("remotes")
 remotes::install_github("gadenbuie/xaringanExtra")
+
+install.packages("fontawesome")


### PR DESCRIPTION
I dropped `xaringanBuilder`. I'll try to work this in elsewhere but xaringanBuilder brings a lot of dependencies with it and since we aren't specifically using it it's probably better not to incldue it in our instructions.

